### PR TITLE
Fixing a problem with file encoding (credits: Antônio Carlos Mariani)

### DIFF
--- a/judge/ideone/lib.php
+++ b/judge/ideone/lib.php
@@ -139,6 +139,10 @@ class judge_ideone extends judge_base
             break;
         }
 
+        if (!mb_detect_encoding($source, "UTF-8", true)) {
+            $source = utf8_encode($source);
+        } 
+
         $status_ideone = array(
             0   => ONLINEJUDGE_STATUS_PENDING,
             11  => ONLINEJUDGE_STATUS_COMPILATION_ERROR,


### PR DESCRIPTION
Hello,

When the submitted file is not utf8, the SOAP fails to send the file.
Doing a utf8_encode solve the problem.

Don't really know if it is the best solution, but it works at moodle.ufsc.br

Kind regards,
Daniel
