### PR TITLE
add memset to testcase/memlimit.c issues#73

### DIFF
--- a/judge/sandbox/sand/testcase/memlimit.c
+++ b/judge/sandbox/sand/testcase/memlimit.c
@@ -3,6 +3,7 @@
 int main(void)
 {
     int *p = malloc(1024*1024*1024);
+    memset(p,0,sizeof(1024*1024*1024));
     free(p);
 
     return 0;

--- a/judge/sandbox/sand/testcase/memlimit.c
+++ b/judge/sandbox/sand/testcase/memlimit.c
@@ -3,7 +3,7 @@
 int main(void)
 {
     int *p = malloc(1024*1024*1024);
-    memset(p,0,sizeof(1024*1024*1024));
+    memset(p, 0, sizeof(1024*1024*1024));
     free(p);
 
     return 0;

--- a/judge/sandbox/sand/testcase/memlimit.c
+++ b/judge/sandbox/sand/testcase/memlimit.c
@@ -3,7 +3,7 @@
 int main(void)
 {
     int *p = malloc(1024*1024*1024);
-    memset(p, 0, sizeof(1024*1024*1024));
+    memset(p, 0, 1024*1024*1024);
     free(p);
 
     return 0;


### PR DESCRIPTION
Unless I add memset function, the make never pass the memory limit test.
./runtest.sh 3 -l memory=1048576 memlimit_test
make: *** [memlimit] Error 1
Following code wouldn't resolve the error: