### PR TITLE
Fix bugs for comparing outputs with Wrong Answer and Presentation Error status

### DIFF
--- a/judgelib.php
+++ b/judgelib.php
@@ -158,7 +158,12 @@ class judge_base{
                     return ONLINEJUDGE_STATUS_WRONG_ANSWER;
                 $tok = strtok(" \n\r\t");
             }
-
+            while ($tok !== false) {
+                if ( !empty(trim($tok)) ) {
+                    return ONLINEJUDGE_STATUS_WRONG_ANSWER;
+                }
+                $tok = strtok(" \n\r\t");
+            }
             return ONLINEJUDGE_STATUS_PRESENTATION_ERROR;
         }
     }

--- a/judgelib.php
+++ b/judgelib.php
@@ -158,11 +158,8 @@ class judge_base{
                     return ONLINEJUDGE_STATUS_WRONG_ANSWER;
                 $tok = strtok(" \n\r\t");
             }
-            while ($tok !== false) {
-                if ( !empty(trim($tok)) ) {
-                    return ONLINEJUDGE_STATUS_WRONG_ANSWER;
-                }
-                $tok = strtok(" \n\r\t");
+            if ($tok !== false) {
+                return ONLINEJUDGE_STATUS_WRONG_ANSWER;
             }
             return ONLINEJUDGE_STATUS_PRESENTATION_ERROR;
         }


### PR DESCRIPTION
As I mentioned in Issue #79, There's a bug in comparing outputs.
And here's the pull request to fix it.

Because when you compare the outputs, you stopped when reach the end of output of test case. And you didn't check if the rest of the stdout of user's program.

If there's some non-blank characters, the judge status should be `Wrong Answer`, but in the old code, the status would be `Presentation Error`.

Feel free to ask me questions and thanks for reviewing my PR.